### PR TITLE
Fix the approval/pending of flashcards

### DIFF
--- a/src/pages/LessonDetail.tsx
+++ b/src/pages/LessonDetail.tsx
@@ -353,7 +353,7 @@ const LessonDetail: React.FC = () => {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-600">Approved</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {flashcards.filter(f => f.status === 'approved').length}
+                {flashcards.filter(f => (f.raw?.approval_status?.toLowerCase() || f.status) === 'approved').length}
               </p>
             </div>
           </div>
@@ -366,7 +366,7 @@ const LessonDetail: React.FC = () => {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-600">Pending</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {flashcards.filter(f => f.status === 'pending').length}
+                {flashcards.filter(f => (f.raw?.approval_status?.toLowerCase() || f.status) === 'pending').length}
               </p>
             </div>
           </div>
@@ -379,7 +379,7 @@ const LessonDetail: React.FC = () => {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-600">Rejected</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {flashcards.filter(f => f.status === 'rejected').length}
+                {flashcards.filter(f => (f.raw?.approval_status?.toLowerCase() || f.status) === 'rejected').length}
               </p>
             </div>
           </div>
@@ -570,13 +570,13 @@ const LessonDetail: React.FC = () => {
 
                     <div className="flex items-center gap-4 mt-3">
                       <span className={`badge ${
-                        flashcard.status === 'approved' ? 'badge-success' : 
-                        flashcard.status === 'pending' ? 'badge-warning' : 'badge-danger'
+                        (flashcard.raw?.approval_status?.toLowerCase() || flashcard.status) === 'approved' ? 'badge-success' :
+                        (flashcard.raw?.approval_status?.toLowerCase() || flashcard.status) === 'pending' ? 'badge-warning' : 'badge-danger'
                       }`}>
-                        {flashcard.status}
+                        {flashcard.raw?.approval_status?.toLowerCase() || flashcard.status}
                       </span>
                       <span className={`badge ${
-                        flashcard.difficulty === 'easy' ? 'badge-success' : 
+                        flashcard.difficulty === 'easy' ? 'badge-success' :
                         flashcard.difficulty === 'medium' ? 'badge-warning' : 'badge-danger'
                       }`}>
                         {flashcard.difficulty}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix flashcard status filtering to use `raw.approval_status`

- Update status display logic for approved/pending/rejected cards

- Ensure consistent status handling across statistics and UI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Flashcard Status"] --> B["Check raw.approval_status"]
  B --> C["Fallback to status field"]
  C --> D["Display in Statistics"]
  C --> E["Display in Badge"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LessonDetail.tsx</strong><dd><code>Fix flashcard status filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/LessonDetail.tsx

<ul><li>Updated status filtering logic to prioritize <code>raw.approval_status</code> field<br> <li> Modified approved, pending, and rejected card count calculations<br> <li> Fixed status badge display to use consistent status source<br> <li> Added fallback to original <code>status</code> field when <code>raw.approval_status</code> <br>unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/antinolabs/learn-lang-admin/pull/8/files#diff-ab48485f39875793d8682c7b288498b06d20d00c630ec0c55987a27a6dcf2c53">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

